### PR TITLE
chore: remove obsolete replacements from synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -44,9 +44,6 @@ common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
 s.copy(templates, excludes=[])
 
-# Fix broken links to cloud.google.com documentation
-s.replace('src/v1beta1/*.ts', '/data-catalog/docs/', 'https://cloud.google.com/data-catalog/docs/')
-
 # Node.js specific cleanup
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])


### PR DESCRIPTION
```
2020-03-05 14:35:23,223 synthtool > No replacements made in src/v1beta1/*.ts for pattern /data-catalog/docs/, maybe replacement is no longer needed?
```
